### PR TITLE
ENH: Colormaps for categorical plots

### DIFF
--- a/ci/envs/latest.yaml
+++ b/ci/envs/latest.yaml
@@ -8,3 +8,4 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
+  - matplotlib

--- a/geopandas_view/test_view.py
+++ b/geopandas_view/test_view.py
@@ -219,6 +219,20 @@ def test_categorical():
         view(nybb, column="BoroName", cmap="nonsense")
 
 
+def test_categories():
+    m = view(
+        nybb,
+        column="BoroName",
+        categories=["Brooklyn", "Staten Island", "Queens", "Bronx", "Manhattan"],
+    )
+    out_str = _fetch_map_string(m)
+    assert '"Bronx","__folium_color":"#c7c7c7"' in out_str
+    assert '"Manhattan","__folium_color":"#9edae5"' in out_str
+    assert '"Brooklyn","__folium_color":"#1f77b4"' in out_str
+    assert '"StatenIsland","__folium_color":"#98df8a"' in out_str
+    assert '""Queens","__folium_color":"#8c564b"' in out_str
+
+
 def test_column_values():
     """
     Check that the dataframe plot method returns same values with an

--- a/geopandas_view/test_view.py
+++ b/geopandas_view/test_view.py
@@ -221,7 +221,7 @@ def test_categorical():
 
 def test_categories():
     m = view(
-        nybb,
+        nybb[['BoroName', 'geometry']],
         column="BoroName",
         categories=["Brooklyn", "Staten Island", "Queens", "Bronx", "Manhattan"],
     )
@@ -230,7 +230,7 @@ def test_categories():
     assert '"Manhattan","__folium_color":"#9edae5"' in out_str
     assert '"Brooklyn","__folium_color":"#1f77b4"' in out_str
     assert '"StatenIsland","__folium_color":"#98df8a"' in out_str
-    assert '""Queens","__folium_color":"#8c564b"' in out_str
+    assert '"Queens","__folium_color":"#8c564b"' in out_str
 
 
 def test_column_values():

--- a/geopandas_view/test_view.py
+++ b/geopandas_view/test_view.py
@@ -201,6 +201,23 @@ def test_categorical():
     assert 'color":"#e41a1c"' in out_str
     assert 'color":"#ff7f00"' in out_str
 
+    # custom list of colors
+    cmap = ["#333432", "#3b6e8c", "#bc5b4f", "#8fa37e", "#efc758"]
+    m = view(nybb, column="BoroName", cmap=cmap)
+    out_str = _fetch_map_string(m)
+    for c in cmap:
+        assert f'"color":"{c}"' in out_str
+
+    # shorter list (to make it repeat)
+    cmap = ["#333432", "#3b6e8c"]
+    m = view(nybb, column="BoroName", cmap=cmap)
+    out_str = _fetch_map_string(m)
+    for c in cmap:
+        assert f'"color":"{c}"' in out_str
+
+    with pytest.raises(ValueError, match="'cmap' is invalid."):
+        view(nybb, column="BoroName", cmap="nonsense")
+
 
 def test_column_values():
     """

--- a/geopandas_view/test_view.py
+++ b/geopandas_view/test_view.py
@@ -3,9 +3,9 @@ import pandas as pd
 import numpy as np
 import folium
 import pytest
+import matplotlib.cm as cm
+import matplotlib.colors as colors
 from geopandas_view import view
-
-from .view import _BRANCA_COLORS
 
 nybb = gpd.read_file(gpd.datasets.get_path("nybb"))
 world = gpd.read_file(gpd.datasets.get_path("naturalearth_lowres"))
@@ -166,31 +166,40 @@ def test_categorical():
     # auto detection
     m = view(world, column="continent")
     out_str = _fetch_map_string(m)
-    assert '"color":"darkred"' in out_str
-    assert '"color":"orange"' in out_str
-    assert '"color":"green"' in out_str
-    assert '"color":"beige"' in out_str
-    assert '"color":"red"' in out_str
-    assert '"color":"lightred"' in out_str
-    assert '"color":"blue"' in out_str
-    assert '"color":"purple"' in out_str
+    assert 'color":"#9467bd","continent":"Europe"' in out_str
+    assert 'color":"#c49c94","continent":"NorthAmerica"' in out_str
+    assert 'color":"#1f77b4","continent":"Africa"' in out_str
+    assert 'color":"#98df8a","continent":"Asia"' in out_str
+    assert 'color":"#ff7f0e","continent":"Antarctica"' in out_str
+    assert 'color":"#9edae5","continent":"SouthAmerica"' in out_str
+    assert 'color":"#7f7f7f","continent":"Oceania"' in out_str
+    assert 'color":"#dbdb8d","continent":"Sevenseas(openocean)"' in out_str
 
     # forced categorical
     m = view(nybb, column="BoroCode", categorical=True)
     out_str = _fetch_map_string(m)
-    assert '"color":"orange"' in out_str
-    assert '"color":"green"' in out_str
-    assert '"color":"red"' in out_str
-    assert '"color":"blue"' in out_str
-    assert '"color":"purple"' in out_str
+    assert 'color":"#9edae5"' in out_str
+    assert 'color":"#c7c7c7"' in out_str
+    assert 'color":"#8c564b"' in out_str
+    assert 'color":"#1f77b4"' in out_str
+    assert 'color":"#98df8a"' in out_str
 
     # pandas.Categorical
     df = world.copy()
     df["categorical"] = pd.Categorical(df["name"])
     m = view(df, column="categorical")
     out_str = _fetch_map_string(m)
-    for c in _BRANCA_COLORS:
+    for c in np.apply_along_axis(colors.to_hex, 1, cm.tab20(range(20))):
         assert f'"color":"{c}"' in out_str
+
+    # custom cmap
+    m = view(nybb, column="BoroName", cmap="Set1")
+    out_str = _fetch_map_string(m)
+    assert 'color":"#999999"' in out_str
+    assert 'color":"#a65628"' in out_str
+    assert 'color":"#4daf4a"' in out_str
+    assert 'color":"#e41a1c"' in out_str
+    assert 'color":"#ff7f00"' in out_str
 
 
 def test_column_values():
@@ -303,7 +312,10 @@ def test_tooltip():
 
     # keywords popup
     m = view(
-        world, tooltip=False, popup=True, popup_kwds=dict(aliases=[0, 1, 2, 3, 4]),
+        world,
+        tooltip=False,
+        popup=True,
+        popup_kwds=dict(aliases=[0, 1, 2, 3, 4]),
     )
     out_str = _fetch_map_string(m)
     assert 'fields=["pop_est","continent","name","iso_a3","gdp_md_est"]' in out_str
@@ -325,7 +337,9 @@ def test_tooltip():
 def test_custom_markers():
     # Markers
     m = view(
-        cities, marker_type="marker", marker_kwds={"icon": folium.Icon(icon="star")},
+        cities,
+        marker_type="marker",
+        marker_kwds={"icon": folium.Icon(icon="star")},
     )
     assert ""","icon":"star",""" in _fetch_map_string(m)
 

--- a/geopandas_view/test_view.py
+++ b/geopandas_view/test_view.py
@@ -232,6 +232,11 @@ def test_categories():
     assert '"StatenIsland","__folium_color":"#98df8a"' in out_str
     assert '"Queens","__folium_color":"#8c564b"' in out_str
 
+    df = nybb.copy()
+    df['categorical'] = pd.Categorical(df["BoroName"])
+    with pytest.raises(ValueError, match="Cannot specify 'categories'"):
+        view(df, 'categorical', categories=["Brooklyn", "Staten Island"])
+
 
 def test_column_values():
     """

--- a/geopandas_view/view.py
+++ b/geopandas_view/view.py
@@ -137,7 +137,6 @@ def view(
         m is given explicitly, height is ignored.
     categories : list-like
         Ordered list-like object of categories to be used for categorical plot.
-        TODO: not implemented yet
     classification_kwds : dict (default None)
         Keyword arguments to pass to mapclassify
     control_scale : bool, (default True)
@@ -232,12 +231,16 @@ def view(
                 gdf[column_name] = column
                 column = column_name
         elif pd.api.types.is_categorical_dtype(gdf[column]):
+            if categories is not None:
+                raise ValueError(
+                    "Cannot specify 'categories' when column has categorical dtype"
+                )
             categorical = True
-        elif gdf[column].dtype is np.dtype("O"):
+        elif gdf[column].dtype is np.dtype("O") or categories:
             categorical = True
 
     if categorical:
-        cat = pd.Categorical(gdf[column])
+        cat = pd.Categorical(gdf[column], categories=categories)
         cmap = cmap if cmap else "tab20"
 
         # colormap exists in matplotlib

--- a/geopandas_view/view.py
+++ b/geopandas_view/view.py
@@ -5,29 +5,8 @@ import pandas as pd
 import geopandas as gpd
 import mapclassify
 import numpy as np
-
-# available named colors
-_BRANCA_COLORS = [
-    "red",
-    "blue",
-    "green",
-    "purple",
-    "orange",
-    "darkred",
-    "lightred",
-    "beige",
-    "darkblue",
-    "darkgreen",
-    "cadetblue",
-    "darkpurple",
-    "white",
-    "pink",
-    "lightblue",
-    "lightgreen",
-    "gray",
-    "black",
-    "lightgray",
-]
+import matplotlib.cm as cm
+import matplotlib.colors as colors
 
 # available color palettes
 _CB_PALETTES = [
@@ -257,13 +236,10 @@ def view(
 
     if categorical:
         cat = pd.Categorical(gdf[column])
-        if len(cat.categories) > len(_BRANCA_COLORS):
-            color = np.take(
-                _BRANCA_COLORS * (len(cat.categories) // len(_BRANCA_COLORS) + 1),
-                cat.codes,
-            )
-        else:
-            color = np.take(_BRANCA_COLORS, cat.codes)
+        cmap = cmap if cmap else "tab20"
+        color = np.apply_along_axis(
+            colors.to_hex, 1, cm.get_cmap(cmap, len(cat.categories))(cat.codes)
+        )
 
     if column is None or categorical:
         _simple(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 geopandas
 folium
 mapclassify
+matplotlib
 pytest
 pytest-cov
 codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 geopandas
 folium
 mapclassify
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,6 @@ setuptools.setup(
     author="Martin Fleischmann",
     author_email="martin@martinfleischmann.net",
     python_requires=">=3.6",
-    install_requires=["geopandas", "folium", "mapclassify"],
+    install_requires=["geopandas", "folium", "mapclassify", "matplotlib"],
     packages=setuptools.find_packages(),
 )


### PR DESCRIPTION
Much simpler take on #3. In categorical plots, we now support same Matplotlib colormaps as static plotting plus a custom list-like of colours (either named or hex). Defaults to `tab20`.

Adding matplotlib as a dependency.

edit: also added support for a custom list of `categories` #5 .

Closes #3
Closes #5