### PR TITLE
BUG: don't fit bounds for a given folium.Map

### DIFF
--- a/geopandas_view/test_view.py
+++ b/geopandas_view/test_view.py
@@ -553,12 +553,14 @@ def test_providers():
     assert '"attribution":"(C)OpenStreetMapcontributors(C)CARTO"' in out_str
     assert '"maxNativeZoom":19,"maxZoom":19,"minZoom":0' in out_str
 
+
 def test_linearrings():
     rings = nybb.explode().exterior
     m = view(rings)
     out_str = _fetch_map_string(m)
 
     assert out_str.count("LineString") == len(rings)
+
 
 def test_mapclassify_categorical_legend():
     m = view(
@@ -640,3 +642,15 @@ def test_mapclassify_categorical_legend():
     ]
     for s in strings:
         assert s in out_str
+
+
+def test_given_m():
+    "Check that geometry is mapped onto a given folium.Map"
+    m = folium.Map()
+    view(nybb, m=m)
+
+    out_str = _fetch_map_string(m)
+
+    assert out_str.count("BoroCode") == 5
+    # should not change map settings
+    assert m.options["zoom"] == 1

--- a/geopandas_view/view.py
+++ b/geopandas_view/view.py
@@ -278,6 +278,9 @@ def view(
             **map_kwds,
         )
 
+        # fit bounds to get a proper zoom level
+        m.fit_bounds([[bounds[1], bounds[0]], [bounds[3], bounds[2]]])
+
     for map_kwd in _MAP_KWARGS:
         kwargs.pop(map_kwd, None)
 
@@ -456,9 +459,6 @@ def view(
         style_function=style_function,
         **kwargs,
     ).add_to(m)
-
-    # fit bounds to get a proper zoom level
-    m.fit_bounds([[bounds[1], bounds[0]], [bounds[3], bounds[2]]])
 
     if legend:
         # NOTE: overlaps should be resolved in branca https://github.com/python-visualization/branca/issues/88


### PR DESCRIPTION
At some point we broke plotting onto a given map, which results in an error on main.

Moving `fit_bounds` to call it only if we create map object.

```py
m = folium.Map()
view(nybb, m=m)
```