### PR TITLE
ENH: honor location and zoom_start

### DIFF
--- a/geopandas_view/test_view.py
+++ b/geopandas_view/test_view.py
@@ -87,6 +87,21 @@ def test_map_settings_custom():
         in out_str
     )
 
+    m = view(nybb, location=(40, 5))
+    assert m.location == [40, 5]
+    assert m.options["zoom"] == 10
+
+    m = view(nybb, zoom_start=8)
+    assert m.location == [
+        pytest.approx(40.70582377450201, rel=1e-6),
+        pytest.approx(-73.9778006856748, rel=1e-6),
+    ]
+    assert m.options["zoom"] == 8
+
+    m = view(nybb, location=(40, 5), zoom_start=8)
+    assert m.location == [40, 5]
+    assert m.options["zoom"] == 8
+
 
 def test_simple_color():
     """Check color settings"""
@@ -656,30 +671,29 @@ def test_given_m():
     # should not change map settings
     assert m.options["zoom"] == 1
 
+
 def test_highlight():
     m = view(nybb, highlight=True)
     out_str = _fetch_map_string(m)
 
     assert '"fillOpacity":0.75' in out_str
 
-    m = view(nybb, highlight=True, highlight_kwds=dict(fillOpacity=1, color='red'))
+    m = view(nybb, highlight=True, highlight_kwds=dict(fillOpacity=1, color="red"))
     out_str = _fetch_map_string(m)
-    
+
     assert '{"color":"red","fillOpacity":1}' in out_str
+
 
 def test_custom_colormaps():
 
-    step = StepColormap(
-        ['green','yellow','red'],
-        vmin=0,
-        vmax=100000000)
+    step = StepColormap(["green", "yellow", "red"], vmin=0, vmax=100000000)
 
-    m = view(world, 'pop_est',cmap=step, tooltip=["name"])
+    m = view(world, "pop_est", cmap=step, tooltip=["name"])
 
     strings = [
-        'fillColor":"#008000ff"', # Green
-        '"fillColor":"#ffff00ff"', # Yellow
-        '"fillColor":"#ff0000ff"', # Red
+        'fillColor":"#008000ff"',  # Green
+        '"fillColor":"#ffff00ff"',  # Yellow
+        '"fillColor":"#ff0000ff"',  # Red
     ]
 
     for s in strings:
@@ -692,11 +706,12 @@ def test_custom_colormaps():
             return "#ff0000"
         else:
             return "#008000"
-    m = view(world, 'pop_est', cmap=my_color_function)
+
+    m = view(world, "pop_est", cmap=my_color_function)
 
     strings = [
         '"color":"#ff0000","fillColor":"#ff0000"',
-        '"color":"#008000","fillColor":"#008000"'
+        '"color":"#008000","fillColor":"#008000"',
     ]
 
     for s in strings:

--- a/geopandas_view/view.py
+++ b/geopandas_view/view.py
@@ -478,7 +478,7 @@ def view(
 
     # add dataframe to map
     folium.GeoJson(
-        gdf.__geo_interface__,
+        gdf.to_json(),
         tooltip=tooltip,
         popup=popup,
         marker=marker,

--- a/geopandas_view/view.py
+++ b/geopandas_view/view.py
@@ -478,7 +478,7 @@ def view(
 
     # add dataframe to map
     folium.GeoJson(
-        gdf.to_json(),
+        gdf.__geo_interface__,
         tooltip=tooltip,
         popup=popup,
         marker=marker,

--- a/geopandas_view/view.py
+++ b/geopandas_view/view.py
@@ -20,6 +20,17 @@ _MAP_KWARGS = [
     "png_enabled",
     "zoom_control",
     "crs",
+    "zoom_start",
+    "left",
+    "top",
+    "position",
+    "min_zoom",
+    "max_zoom",
+    "min_lat",
+    "max_lat",
+    "min_lon",
+    "max_lon",
+    "max_bounds",
 ]
 
 
@@ -251,6 +262,12 @@ def view(
             x = mean([bounds[0], bounds[2]])
             y = mean([bounds[1], bounds[3]])
             location = (y, x)
+            if "zoom_start" in kwargs.keys():
+                fit = False
+            else:
+                fit = True
+        else:
+            fit = False
 
         # get a subset of kwargs to be passed to folium.Map
         map_kwds = {i: kwargs[i] for i in kwargs.keys() if i in _MAP_KWARGS}
@@ -275,7 +292,8 @@ def view(
         )
 
         # fit bounds to get a proper zoom level
-        m.fit_bounds([[bounds[1], bounds[0]], [bounds[3], bounds[2]]])
+        if fit:
+            m.fit_bounds([[bounds[1], bounds[0]], [bounds[3], bounds[2]]])
 
     for map_kwd in _MAP_KWARGS:
         kwargs.pop(map_kwd, None)


### PR DESCRIPTION
Closes #48

Use `m.fit_bounds` only if neither `location` or `zoom_start` is passed.