### PR TITLE
Change default styling

### DIFF
--- a/geopandas_view/test_view.py
+++ b/geopandas_view/test_view.py
@@ -707,7 +707,7 @@ def test_custom_colormaps():
         else:
             return "#008000"
 
-    m = view(world, "pop_est", cmap=my_color_function)
+    m = view(world, "pop_est", cmap=my_color_function, legend=False)
 
     strings = [
         '"color":"#ff0000","fillColor":"#ff0000"',

--- a/geopandas_view/test_view.py
+++ b/geopandas_view/test_view.py
@@ -315,7 +315,7 @@ def test_tooltip():
     """Test tooltip"""
     # default with no tooltip or popup
     m = view(world)
-    assert "GeoJsonTooltip" not in str(m.to_dict())
+    assert "GeoJsonTooltip" in str(m.to_dict())
     assert "GeoJsonPopup" not in str(m.to_dict())
 
     # True
@@ -663,7 +663,7 @@ def test_mapclassify_categorical_legend():
 def test_given_m():
     "Check that geometry is mapped onto a given folium.Map"
     m = folium.Map()
-    view(nybb, m=m)
+    view(nybb, m=m, tooltip=False, highlight=False)
 
     out_str = _fetch_map_string(m)
 

--- a/geopandas_view/view.py
+++ b/geopandas_view/view.py
@@ -42,11 +42,11 @@ def view(
     m=None,
     tiles="OpenStreetMap",
     attr=None,
-    tooltip=False,
+    tooltip=True,
     popup=False,
-    highlight=False,
+    highlight=True,
     categorical=False,
-    legend=None,
+    legend=True,
     scheme=None,
     k=5,
     vmin=None,
@@ -103,25 +103,25 @@ def view(
         to check their terms and conditions and to provide attribution with the attr keyword.
     attr : str (default None)
         Map tile attribution; only required if passing custom tile URL.
-    tooltip : bool, str, int, list (default False)
+    tooltip : bool, str, int, list (default True)
         Display GeoDataFrame attributes when hovering over the object.
         Integer specifies first n columns to be included, ``True`` includes all
         columns. ``False`` removes tooltip. Pass string or list of strings to specify a
-        column(s). Defaults to ``False``.
+        column(s). Defaults to ``True``.
     popup : bool, str, int, list (default False)
         Input GeoDataFrame attributes for object displayed when clicking.
         Integer specifies first n columns to be included, ``True`` includes all
         columns. ``False`` removes tooltip. Pass string or list of strings to specify a
         column(s). Defaults to ``False``.
-    highlight : bool (default False)
+    highlight : bool (default True)
         Enable highlight functionality when hovering over a geometry.
     categorical : bool (default False)
         If False, cmap will reflect numerical values of the
         column being plotted. For non-numerical columns, this
         will be set to True.
-    legend : bool (default None)
-        Plot a categorical legend in categorical plots.
-        Ignored if no `column` is given, or if `color` is given.
+    legend : bool (default True)
+        Plot a legend in choropleth plots.
+        Ignored if no `column` is given.
     scheme : str (default None)
         Name of a choropleth classification scheme (requires mapclassify).
         A mapclassify.MapClassifier object will be used
@@ -402,11 +402,9 @@ def view(
         if marker_type is None:
             marker_type = "circle"
 
-    # set default style
+    # # set default style
     if "fillOpacity" not in style_kwds:
         style_kwds["fillOpacity"] = 0.5
-    if "weight" not in style_kwds:
-        style_kwds["weight"] = 1
 
     # specify color
     if color is not None:

--- a/geopandas_view/view.py
+++ b/geopandas_view/view.py
@@ -402,9 +402,11 @@ def view(
         if marker_type is None:
             marker_type = "circle"
 
-    # # set default style
+    # set default style
     if "fillOpacity" not in style_kwds:
         style_kwds["fillOpacity"] = 0.5
+    if "weight" not in style_kwds:
+        style_kwds["weight"] = 2
 
     # specify color
     if color is not None:


### PR DESCRIPTION
Applies opinionated default styling following @jorisvandenbossche's suggestions in #29 (which I agree with).

Compared to folium default we now:

- use darker fill (opacity 0.5)
- use highlight (change to opacity 0.75 by default)
- show tooltip (all fields)
- show legend (when applicable)
- use line weight 2 pixels (balance between folium default of 3 which can be a bit rough and previous one of 1 pixel)

Closes #29