### PR TITLE
ENH: support matplotlib.Colormap object as cmap

### DIFF
--- a/geopandas_view/test_view.py
+++ b/geopandas_view/test_view.py
@@ -721,3 +721,19 @@ def test_custom_colormaps():
 
     for s in strings:
         assert s in _fetch_map_string(m)
+
+    # matplotlib.Colormap
+    cmap = colors.ListedColormap(["red", "green", "blue", "white", "black"])
+
+    m = view(nybb, "BoroName", cmap=cmap)
+    strings = [
+        '"fillColor":"#ff0000"',  # Red
+        '"fillColor":"#008000"',  # Green
+        '"fillColor":"#0000ff"',  # Blue
+        '"fillColor":"#ffffff"',  # White
+        '"fillColor":"#000000"',  # Black
+    ]
+
+    out_str = _fetch_map_string(m)
+    for s in strings:
+        assert s in out_str

--- a/geopandas_view/view.py
+++ b/geopandas_view/view.py
@@ -77,8 +77,8 @@ def view(
     column : str, np.array, pd.Series (default None)
         The name of the dataframe column, np.array, or pd.Series to be plotted.
         If np.array or pd.Series are used then it must have same length as dataframe.
-    cmap : str, branca.colormap, self-defined function fun(column)->str (default None)
-        The name of a colormap recognized by matplotlib, a list-like of colors,
+    cmap : str, matplotlib.Colormap, branca.colormap, self-defined function fun(column)->str (default None)
+        The name of a colormap recognized by matplotlib, a list-like of colors, matplotlib.Colormap, 
         a branca colormap or function that returns a named color or hex based on the column
         value, e.g.:
             def my_colormap(value):  # scalar value defined in 'column'
@@ -335,6 +335,11 @@ def view(
                 legend_colors = np.apply_along_axis(
                     colors.to_hex, 1, cm.get_cmap(cmap, N)(range(N))
                 )
+
+            # colormap is matplotlib.Colormap
+            elif isinstance(cmap, colors.Colormap):
+                color = np.apply_along_axis(colors.to_hex, 1, cmap(cat.codes))
+                legend_colors = np.apply_along_axis(colors.to_hex, 1, cmap(range(N)))
 
             # custom list of colors
             elif pd.api.types.is_list_like(cmap):


### PR DESCRIPTION
Static plotting works with `matplotlib.colors.Colormap` objects, view should as well.

```
import geopandas
from geopandas_view import view
from matplotlib.colors import ListedColormap

df = geopandas.read_file(geopandas.datasets.get_path('nybb'))
cmap = ListedColormap(["red", "green", "blue", "pink", "black"])
view(df, "BoroName", cmap=cmap)
```